### PR TITLE
Docker Containers for Windows 10 - Enable Non-Interactive Installs of Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo 'root:${ROOT_PASSWORD}' | chpasswd; \
 
 # Install all Buildroot deps and prepare buildroot
 WORKDIR /root
-RUN apt-get -q -y install \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install \
     bc \
     build-essential \
     bzr \


### PR DESCRIPTION
**The Issue**

On Docker Containers for Windows 10 I am unable to answer `yes` to install prompts from `apt-get` with the interactive command prompt.

**Expected Results**

Users should be able to complete the container build progress on Docker Containers for Windows without issue.

**Fixes**

I added a command for the Ubuntu install to automatically answer prompts in non-interactive mode. 

**Testing**

I am currently testing this now on Windows 10 Pro, Surface Book 2, with Docker Containers enabled with Linux Containers. 